### PR TITLE
Fix instrument_sql to not break highlighting and types

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -7,6 +7,7 @@ pub fn extend_fields(
 ) -> String {
     // either extend `fields` attribute in-place or just add it, if it was not set
     if input.is_empty() {
+        assert!(required_attrs.is_none(), "expected {required_attrs:?} attributes");
         format!(r#"fields({extra_fields})"#)
     } else if input.contains("fields(") {
         let (modified_input, extracted_fields) = extract_required_attributes(input, required_attrs);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,62 +23,48 @@ use quote::quote;
 const HTTP: &str = r#""span.type" = "http""#;
 const QUEUE_CONSUMER: &str = r#""span.type" = "queue", span.kind = "consumer", messaging.system = "pgmq""#;
 const QUEUE_PRODUCER: &str = r#""span.type" = "queue", span.kind = "producer", messaging.system = "pgmq""#;
-const SQL: &str = r#""span.type" = "sql", service.name = "database", db.system = "postgresql""#;
+const SQL: &str = r#""span.type" = "sql""#;
 const WEB: &str = r#""span.type" = "web""#;
 
 #[proc_macro_attribute]
 pub fn instrument_custom(attr: TokenStream, item: TokenStream) -> TokenStream {
-    let attr: proc_macro2::TokenStream = attr.into();
-    let item: proc_macro2::TokenStream = item.into();
-    let required_attrs = Some(vec!["service_name"]);
-    generate_instrumented_method(attr, item, "", required_attrs).into()
+    generate_instrumented_method(attr, item, "", Some(vec!["service_name"])).into()
 }
 
 #[proc_macro_attribute]
 pub fn instrument_http(attr: TokenStream, item: TokenStream) -> TokenStream {
-    let attr: proc_macro2::TokenStream = attr.into();
-    let item: proc_macro2::TokenStream = item.into();
-    let required_attrs = Some(vec!["service_name"]);
-    generate_instrumented_method(attr, item, HTTP, required_attrs).into()
+    generate_instrumented_method(attr, item, HTTP, Some(vec!["service_name"])).into()
 }
 
 #[proc_macro_attribute]
 pub fn instrument_queue_consumer(attr: TokenStream, item: TokenStream) -> TokenStream {
-    let attr: proc_macro2::TokenStream = attr.into();
-    let item: proc_macro2::TokenStream = item.into();
-    let required_attrs = Some(vec!["service_name"]);
-    generate_instrumented_method(attr, item, QUEUE_CONSUMER, required_attrs).into()
+    generate_instrumented_method(attr, item, QUEUE_CONSUMER, Some(vec!["service_name"])).into()
 }
 
 #[proc_macro_attribute]
 pub fn instrument_queue_producer(attr: TokenStream, item: TokenStream) -> TokenStream {
-    let attr: proc_macro2::TokenStream = attr.into();
-    let item: proc_macro2::TokenStream = item.into();
-    let required_attrs = Some(vec!["service_name"]);
-    generate_instrumented_method(attr, item, QUEUE_PRODUCER, required_attrs).into()
+    generate_instrumented_method(attr, item, QUEUE_PRODUCER, Some(vec!["service_name"])).into()
 }
 
 #[proc_macro_attribute]
 pub fn instrument_sql(attr: TokenStream, item: TokenStream) -> TokenStream {
-    let attr: proc_macro2::TokenStream = attr.into();
-    let item: proc_macro2::TokenStream = item.into();
     generate_instrumented_method(attr, item, SQL, None).into()
 }
 
 #[proc_macro_attribute]
 pub fn instrument_web(attr: TokenStream, item: TokenStream) -> TokenStream {
-    let attr: proc_macro2::TokenStream = attr.into();
-    let item: proc_macro2::TokenStream = item.into();
     generate_instrumented_method(attr, item, WEB, None).into()
 }
 
 #[allow(clippy::needless_pass_by_value)]
 fn generate_instrumented_method(
-    attr: proc_macro2::TokenStream,
-    item: proc_macro2::TokenStream,
+    attr: TokenStream,
+    item: TokenStream,
     extra_fields: &str,
     required_attrs: Option<Vec<&str>>,
 ) -> proc_macro2::TokenStream {
+    let attr: proc_macro2::TokenStream = attr.into();
+    let item: proc_macro2::TokenStream = item.into();
     let extended_attr: proc_macro2::TokenStream =
         attr::extend_fields(attr.to_string().as_str(), extra_fields, required_attrs)
             .parse()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ pub fn instrument_custom(attr: TokenStream, item: TokenStream) -> TokenStream {
     let attr: proc_macro2::TokenStream = attr.into();
     let item: proc_macro2::TokenStream = item.into();
     let required_attrs = Some(vec!["service_name"]);
-    generate_instrumented_method(attr, item, "", None, required_attrs).into()
+    generate_instrumented_method(attr, item, "", required_attrs).into()
 }
 
 #[proc_macro_attribute]
@@ -39,7 +39,7 @@ pub fn instrument_http(attr: TokenStream, item: TokenStream) -> TokenStream {
     let attr: proc_macro2::TokenStream = attr.into();
     let item: proc_macro2::TokenStream = item.into();
     let required_attrs = Some(vec!["service_name"]);
-    generate_instrumented_method(attr, item, HTTP, None, required_attrs).into()
+    generate_instrumented_method(attr, item, HTTP, required_attrs).into()
 }
 
 #[proc_macro_attribute]
@@ -47,7 +47,7 @@ pub fn instrument_queue_consumer(attr: TokenStream, item: TokenStream) -> TokenS
     let attr: proc_macro2::TokenStream = attr.into();
     let item: proc_macro2::TokenStream = item.into();
     let required_attrs = Some(vec!["service_name"]);
-    generate_instrumented_method(attr, item, QUEUE_CONSUMER, None, required_attrs).into()
+    generate_instrumented_method(attr, item, QUEUE_CONSUMER, required_attrs).into()
 }
 
 #[proc_macro_attribute]
@@ -55,22 +55,21 @@ pub fn instrument_queue_producer(attr: TokenStream, item: TokenStream) -> TokenS
     let attr: proc_macro2::TokenStream = attr.into();
     let item: proc_macro2::TokenStream = item.into();
     let required_attrs = Some(vec!["service_name"]);
-    generate_instrumented_method(attr, item, QUEUE_PRODUCER, None, required_attrs).into()
+    generate_instrumented_method(attr, item, QUEUE_PRODUCER, required_attrs).into()
 }
 
 #[proc_macro_attribute]
 pub fn instrument_sql(attr: TokenStream, item: TokenStream) -> TokenStream {
     let attr: proc_macro2::TokenStream = attr.into();
     let item: proc_macro2::TokenStream = item.into();
-    let required_fields = Some(vec!["db.operation"]);
-    generate_instrumented_method(attr, item, SQL, required_fields, None).into()
+    generate_instrumented_method(attr, item, SQL, None).into()
 }
 
 #[proc_macro_attribute]
 pub fn instrument_web(attr: TokenStream, item: TokenStream) -> TokenStream {
     let attr: proc_macro2::TokenStream = attr.into();
     let item: proc_macro2::TokenStream = item.into();
-    generate_instrumented_method(attr, item, WEB, None, None).into()
+    generate_instrumented_method(attr, item, WEB, None).into()
 }
 
 #[allow(clippy::needless_pass_by_value)]
@@ -78,11 +77,10 @@ fn generate_instrumented_method(
     attr: proc_macro2::TokenStream,
     item: proc_macro2::TokenStream,
     extra_fields: &str,
-    required_fields: Option<Vec<&str>>,
     required_attrs: Option<Vec<&str>>,
 ) -> proc_macro2::TokenStream {
     let extended_attr: proc_macro2::TokenStream =
-        attr::extend_fields(attr.to_string().as_str(), extra_fields, required_fields, required_attrs)
+        attr::extend_fields(attr.to_string().as_str(), extra_fields, required_attrs)
             .parse()
             .unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ use quote::quote;
 const HTTP: &str = r#""span.type" = "http""#;
 const QUEUE_CONSUMER: &str = r#""span.type" = "queue", span.kind = "consumer", messaging.system = "pgmq""#;
 const QUEUE_PRODUCER: &str = r#""span.type" = "queue", span.kind = "producer", messaging.system = "pgmq""#;
-const SQL: &str = r#""span.type" = "sql""#;
+const SQL: &str = r#""span.type" = "sql", service.name = "database", db.system = "postgresql""#;
 const WEB: &str = r#""span.type" = "web""#;
 
 #[proc_macro_attribute]


### PR DESCRIPTION
# Generated description

Dear maintainer, below is a concise technical summary of the changes proposed in this PR:
This pull request refines the `instrument_sql` function to ensure it does not disrupt syntax highlighting and type checking. The changes primarily involve the removal of `required_fields` from various function calls and assertions, focusing on `required_attrs` instead. The `extend_fields` function in `attr.rs` and the `generate_instrumented_method` in `lib.rs` are the main areas of modification, streamlining the handling of attributes and fields.

## Topics
### [Refactor `extend_fields` to remove `required_fields` and adjust assertions for `required_attrs`. This simplifies the function logic and ensures compatibility with the updated `instrument_sql` function.](https://baz.co/changes/baz-scm/tracing-datadog-macros/1?tool=ast&topic=Extend+Fields+Refactor)
* [`src/attr.rs`](https://github.com/baz-scm/tracing-datadog-macros/pull/1/files#diff-e47dc5ac75eba9b921cbcd39a55310f28c152f14f38e5b496b3b8c3f805ac0e5)
### [Update `generate_instrumented_method` to align with the new `extend_fields` signature, removing `required_fields` and focusing on `required_attrs`. This change is crucial for maintaining the integrity of the `instrument_sql` function.](https://baz.co/changes/baz-scm/tracing-datadog-macros/1?tool=ast&topic=Generate+Method+Update)
* [`src/lib.rs`](https://github.com/baz-scm/tracing-datadog-macros/pull/1/files#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759)
### [Adjustments in `instrument_*` functions to remove unnecessary conversions and align with the updated `generate_instrumented_method`. This ensures consistent behavior across different instrumentation functions.](https://baz.co/changes/baz-scm/tracing-datadog-macros/1?tool=ast&topic=Instrument+Functions+Update)
* [`src/lib.rs`](https://github.com/baz-scm/tracing-datadog-macros/pull/1/files#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759)
### [Test updates to reflect changes in function signatures and logic, ensuring that the tests accurately validate the new behavior of `extend_fields` and related functions.](https://baz.co/changes/baz-scm/tracing-datadog-macros/1?tool=ast&topic=Test+Adjustments)
* [`src/attr.rs`](https://github.com/baz-scm/tracing-datadog-macros/pull/1/files#diff-e47dc5ac75eba9b921cbcd39a55310f28c152f14f38e5b496b3b8c3f805ac0e5)
