### PR TITLE
chore: enable CodeQL

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,34 @@
+name: "CodeQL Analysis"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '0 20 * * 6'
+
+permissions:
+  contents: read
+
+env:
+  CODEQL_ENABLE_EXPERIMENTAL_FEATURES: true # CodeQL support for Rust is experimental
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: rust
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths-ignore:
       - 'README.md'
+  schedule:
+    - cron: '0 20 * * 6'
 
 permissions:
   contents: read


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enables CodeQL analysis for the project by adding a new GitHub Actions workflow. Configures CodeQL to run on push, pull requests, and weekly schedules, focusing on analyzing Rust code with experimental features enabled.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>gruebel</td><td>feat-add-release-flow-2</td><td>December 17, 2024</td></tr></table></details>
This pull request is reviewed by Baz. Join @gruebel and the rest of your team on <a href=https://main.baz.ninja/changes/baz-scm/tracing-datadog-macros/7?tool=ast>(Baz)</a>.