### PR TITLE
fix!: add dedicated MSRV CI test and increase MSRV to 1.68.2

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+[resolver]
+# https://doc.rust-lang.org/cargo/reference/config.html#resolverincompatible-rust-versions
+incompatible-rust-versions = "fallback"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,7 +43,7 @@ jobs:
   msrv:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.67.1 # MSRV
           - stable
           - beta
     steps:
@@ -40,3 +39,16 @@ jobs:
         run: cargo fmt --check --all
       - name: Clippy check
         run: cargo clippy --workspace
+
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-msrv
+      - name: Check MSRV
+        run: cargo msrv verify --output-format json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tracing-datadog-macros"
 version = "0.0.3"
 edition = "2021"
-rust-version = "1.67.1" # MSRV
+rust-version = "1.68.2" # MSRV
 
 description = "Collection of convenience macros to use with Datadog tracing"
 keywords = ["datadog", "tracing"]


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Increase the Minimum Supported Rust Version (MSRV) for the <code>tracing-datadog-macros</code> crate to <code>1.68.2</code> and introduce a dedicated GitHub Actions workflow to verify the MSRV.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/baz-scm/tracing-datadog-macros/12?tool=ast&topic=Add+MSRV+CI+Test>Add MSRV CI Test</a>
        </td><td>Introduce a new GitHub Actions workflow job named <code>msrv</code> to automatically verify the Minimum Supported Rust Version using <code>cargo-msrv</code>.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/pr.yml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>anton.gruebel@gmail.com</td><td>chore-enable-CodeQL-7</td><td>May 06, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/baz-scm/tracing-datadog-macros/12?tool=ast&topic=Increase+MSRV>Increase MSRV</a>
        </td><td>Update the Minimum Supported Rust Version (MSRV) for the <code>tracing-datadog-macros</code> crate to <code>1.68.2</code> and configure the Cargo resolver to handle incompatible Rust versions.<details><summary>Modified files (2)</summary><ul><li>Cargo.toml</li>
<li>.cargo/config.toml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>internal-baz-ci-app[bot]</td><td>chore-main-release-0.0...</td><td>February 25, 2025</td></tr>
<tr><td>anton.gruebel@gmail.com</td><td>feat-add-release-flow-2</td><td>December 17, 2024</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/tracing-datadog-macros/12?tool=ast>(Baz)</a>.